### PR TITLE
Add NO_POSITION check to return function to prevent ArrayIndexOutOfBoundsException

### DIFF
--- a/flexbox/src/main/java/jp/co/matchingagent/cocotsure/flexbox/FlexboxHelper.java
+++ b/flexbox/src/main/java/jp/co/matchingagent/cocotsure/flexbox/FlexboxHelper.java
@@ -1003,7 +1003,7 @@ class FlexboxHelper {
             // Prevents ArrayIndexOutOfBoundsException occurring at the beginning of the following 'for loop'
             // TODO Determine when exactly the index becomes NO_POSITION
             if (flexLineIndex == NO_POSITION) {
-                flexLineIndex = 0;
+                return;
             }
         }
         List<FlexLine> flexLines = mFlexContainer.getFlexLinesInternal();

--- a/flexbox/src/main/java/jp/co/matchingagent/cocotsure/flexbox/FlexboxHelper.java
+++ b/flexbox/src/main/java/jp/co/matchingagent/cocotsure/flexbox/FlexboxHelper.java
@@ -1000,6 +1000,11 @@ class FlexboxHelper {
         int flexLineIndex = 0;
         if (mIndexToFlexLine != null) {
             flexLineIndex = mIndexToFlexLine[fromIndex];
+            // Prevents ArrayIndexOutOfBoundsException occurring at the beginning of the following 'for loop'
+            // TODO Determine when exactly the index becomes NO_POSITION
+            if (flexLineIndex == NO_POSITION) {
+                flexLineIndex = 0;
+            }
         }
         List<FlexLine> flexLines = mFlexContainer.getFlexLinesInternal();
         for (int i = flexLineIndex, size = flexLines.size(); i < size; i++) {


### PR DESCRIPTION
We see some ArrayIndexOutOfBoundsException due to some situations where the first index value of for loop becomes -1. As we cannot determine the cause of this situation right now we simply return the function if this illegal situation occurs.