### PR TITLE
Add NO_POSITION check to return function

### DIFF
--- a/flexbox/src/main/java/jp/co/matchingagent/cocotsure/flexbox/FlexboxHelper.java
+++ b/flexbox/src/main/java/jp/co/matchingagent/cocotsure/flexbox/FlexboxHelper.java
@@ -1628,6 +1628,11 @@ class FlexboxHelper {
             int flexLineIndex = 0;
             if (mIndexToFlexLine != null) {
                 flexLineIndex = mIndexToFlexLine[fromIndex];
+                // Prevents ArrayIndexOutOfBoundsException occurring at the beginning of the following 'for loop'
+                // TODO Determine when exactly the index becomes NO_POSITION
+                if (flexLineIndex == NO_POSITION) {
+                    return;
+                }
             }
             List<FlexLine> flexLines = mFlexContainer.getFlexLinesInternal();
             for (int i = flexLineIndex, size = flexLines.size(); i < size; i++) {


### PR DESCRIPTION
We see some ArrayIndexOutOfBoundsException due to some situations where the first index value of for loop becomes -1. As we cannot determine the cause of this situation right now we simply return the function if this illegal situation occurs.
Similar to this: https://github.com/MatchingAgent/flexbox-layout/pull/3